### PR TITLE
Use 1 instead of AudioFormat.CHANNEL_IN_MONO in builder.

### DIFF
--- a/reactiveaudiorecord/src/main/java/com/minimize/library/RecorderOnSubscribe.java
+++ b/reactiveaudiorecord/src/main/java/com/minimize/library/RecorderOnSubscribe.java
@@ -52,7 +52,7 @@ public class RecorderOnSubscribe implements Observable.OnSubscribe<short[]>, Run
             mSampleRate = 44100;
             mBitsPerSecond = AudioFormat.ENCODING_PCM_16BIT;
             mAudioSource = MediaRecorder.AudioSource.MIC;
-            mChannels = AudioFormat.CHANNEL_IN_MONO;
+            mChannels = 1;
         }
 
         public Builder sampleRate(int sampleRate)


### PR DESCRIPTION
AudioFormat.CHANNEL_IN_MONO as default gets overwritten to AudioFormat.CHANNEL_IN_STEREO. AudioFormat.CHANNEL_IN_MONO is 0x10...
